### PR TITLE
Add `get_r` and `put` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Sftp
 
-This gem wraps shell `sftp` to make working with it in ruby scripts easier
+This gem wraps shell `sftp` to make working with it in Ruby scripts easier.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's `Gemfile`:
 
 ```ruby
 gem "sftp",
@@ -24,7 +24,7 @@ Or install it yourself as:
 
 Basic configuration:
 ```
-require 'sftp'
+require "sftp"
 
 SFTP.configure do |config|
   config.user = "your_sftp_user"
@@ -35,7 +35,7 @@ end
 client = SFTP.client
 ```
 
-`SFTP.client.ls` returns an array of path names to files in the sftp user's directory directory
+`SFTP.client.ls` returns an array of path names to files in the SFTP user's directory.
 
 ```
 SFTP.client.ls
@@ -45,32 +45,54 @@ SFTP.client.ls("directory")
 #returns ["directory/file3.txt","directory/file4.txt"]
 ```
 
-`SFTP.client.get(from,to)` downloads the file from the `from` path on the sftp server to the `to` path on the local machine
+`SFTP.client.get(path, destination)` downloads the file from `path` on the SFTP server to the `destination` path on the local machine.
 
-```
-SFTP.client.get("direcotry/file3.txt","./")
+```sh
+SFTP.client.get("direcotry/file3.txt", "./")
 ls .
 "file3.txt"
 ```
 
-`SFTP.client.rename(from, to)` renames a file on the sftp server.
-```
-SFTP.client.ls
-# returns ["file1.txt,"file2.txt","directory"]
-SFTP.client.rename("file1.txt,"directory/renamed.txt")
-SFT.client.ls
-# returns ["file2.txt","directory"]
+`SFTP.client.get_r(path, destination)` downloads everything (files and/or directories) found at `path` on the SFTP server to the `destination` path on the local machine.
+```sh
 SFTP.client.ls("directory")
-#returns ["directory/file3.txt","directory/file4.txt", "directory/renamed.txt"]
+# returns ["file1.txt", "file2.txt"]
+SFTP.client.get_r("directory", "./")
+ls .
+# directory
+ls directory
+# file1.txt   file2.txt
+```
+
+`SFTP.client.rename(from, to)` renames a file on the SFTP server.
+
+```sh
+SFTP.client.ls
+# returns ["file1.txt, "file2.txt", "directory"]
+SFTP.client.rename("file1.txt, "directory/renamed.txt")
+SFT.client.ls
+# returns ["file2.txt", "directory"]
+SFTP.client.ls("directory")
+# returns ["directory/file3.txt", "directory/file4.txt", "directory/renamed.txt"]
+```
+
+`SFTP.client.put(path, destination)` sends a file from `path` on the local machine to the `destination` path on the SFTP server.
+
+```sh
+ls .
+# "file1.txt"
+SFTP.client.put("file.txt", "directory")
+SFTP.client.ls("directory")
+# returns ["file1.txt"]
 ```
 
 ## Development
 
-In the application root folder set up the ssh_keys
+In the application root folder, set up the ssh_keys:
 ```
 ./bin/set_up_development_ssh_keys.sh
 ```
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/mlibraray/sftp
+Bug reports and pull requests are welcome on GitHub at https://github.com/mlibrary/sftp

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ This gem wraps shell `sftp` to make working with it in ruby scripts easier
 
 ## Installation
 
-Add this line to your application's Gemfile (niquerio todo: figure out what actually needs to be put here):
+Add this line to your application's Gemfile:
 
 ```ruby
-gem 'sftp'
+gem "sftp",
+  git: "https://github.com/mlibrary/sftp",
+  tag: "{latest_tag_goes_here}"
 ```
 
 And then execute:

--- a/lib/sftp/client.rb
+++ b/lib/sftp/client.rb
@@ -16,8 +16,16 @@ module SFTP
       run_an_sftp_command("$'@get #{path} #{destination}'")
     end
 
+    def get_r(path, destination)
+      run_an_sftp_command("$'@get -R #{path} #{destination}'")
+    end
+
     def rename(from, to)
       run_an_sftp_command("$'@rename #{from} #{to}'")
+    end
+
+    def put(path, destination)
+      run_an_sftp_command("$'@put #{path} #{destination}'")
     end
 
     private

--- a/spec/sftp_spec.rb
+++ b/spec/sftp_spec.rb
@@ -80,4 +80,18 @@ RSpec.describe SFTP::Client do
       subject.get("my/source/path", "my/destination/path")
     end
   end
+  context "#get_r" do
+    it "sends appropriate basic message to shell" do
+      command = [@sftp_command_base, "$'@get -R my/source/path my/destination/path'"].flatten
+      expect(@shell).to receive(:run).with(command)
+      subject.get_r("my/source/path", "my/destination/path")
+    end
+  end
+  context "#put" do
+    it "sends appropriate basic message to shell" do
+      command = [@sftp_command_base, "$'@put my/source/path my/destination/path'"].flatten
+      expect(@shell).to receive(:run).with(command)
+      subject.put("my/source/path", "my/destination/path")
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `Client` methods for fetching directories and their contents (`get_r`) and for sending single files (`put`). It also makes some updates to the `README.md`, including more specific `Gemfile` instructions, updated parameter names in examples, and some misc. typographical fixes. 