### PR TITLE
Throw `SFTP::Error` when Bash process started by `Shell` fails

### DIFF
--- a/lib/sftp/shell.rb
+++ b/lib/sftp/shell.rb
@@ -3,6 +3,9 @@ module SFTP
     def self.run(array_of_commands)
       command_str = [array_of_commands].join(" ")
       `bash  -c \"#{command_str}\"`
+      return if $CHILD_STATUS.success?
+
+      raise Error, "Error occurred during SFTP process: #{$CHILD_STATUS.exitstatus}"
     end
   end
 end

--- a/spec/sftp_spec.rb
+++ b/spec/sftp_spec.rb
@@ -95,3 +95,15 @@ RSpec.describe SFTP::Client do
     end
   end
 end
+
+RSpec.describe SFTP::Shell do
+  before(:each) do
+    @shell = SFTP::Shell
+  end
+
+  context "#run" do
+    it "throws Error when run fails" do
+      expect { @shell.run ["gobbledegook"] }.to raise_error(SFTP::Error)
+    end
+  end
+end


### PR DESCRIPTION
This PR raises an error if the Bash process started by `Shell` fails. This seems to me improved behavior over silently failing and continuing, though I'm happy to listen to other views.